### PR TITLE
chore: add aqua policy and registry configuration files

### DIFF
--- a/.aqua-policy.yaml
+++ b/.aqua-policy.yaml
@@ -1,0 +1,13 @@
+---
+# aqua Policy
+# https://aquaproj.github.io/
+registries:
+- name: local
+  type: local
+  path: .aqua-registry.yaml
+- type: standard
+  ref: semver(">= 3.0.0")
+packages:
+- registry: local
+  name: honnef.co/go/tools/cmd/staticcheck
+- registry: standard

--- a/.aqua-registry.yaml
+++ b/.aqua-registry.yaml
@@ -1,0 +1,10 @@
+---
+# aqua Registry
+# https://aquaproj.github.io/
+packages:
+- name: honnef.co/go/tools/cmd/staticcheck
+  type: go_install
+  repo_owner: dominikh
+  repo_name: go-tools
+  path: honnef.co/go/tools/cmd/staticcheck
+  description: Go static analysis, detecting bugs, performance issues, and much more.

--- a/.aqua.yaml
+++ b/.aqua.yaml
@@ -3,8 +3,12 @@
 registries:
 - type: standard
   ref: v4.262.0 # renovate: depName=aquaproj/aqua-registry
+- name: local
+  type: local
+  path: .aqua-registry.yaml
 packages:
-- name: dominikh/go-tools/staticcheck@2024.1.1
+- name: honnef.co/go/tools/cmd/staticcheck@2024.1.1
+  registry: local
 - name: goreleaser/goreleaser@v2.4.8
 - name: securego/gosec@v2.21.4
 - name: reviewdog/reviewdog@v0.20.2

--- a/.github/actions/setup-aqua/action.yaml
+++ b/.github/actions/setup-aqua/action.yaml
@@ -12,6 +12,9 @@ runs:
     with:
       path: ${{ steps.cache-dir.outputs.aqua }}
       key: aqua-tools-${{ runner.os }}-${{ hashFiles('**/.aqua.yaml') }}
+  - name: Allow Local Registry
+    shell: bash
+    run: echo "AQUA_POLICY_CONFIG=${{ github.workspace }}/.aqua-policy.yaml" >> $GITHUB_ENV
   - name: Setup Aqua
     uses: aquaproj/aqua-installer@f13c5d2f0357708d85477aabe50fd3f725528745 # v3.1.0
     with:


### PR DESCRIPTION
Fixed an issue in Staticcheck 2024.1 (v0.5.0) where the check would fail
if the Staticcheck binary version was older than the Go version.

see also: https://github.com/dominikh/go-tools/releases/tag/2024.1
